### PR TITLE
README: Capitalize P in "WordPress"

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [Haven](https://havenweb.org) is a simple blog application (formerly called SimpleBlog) built with Ruby on Rails, some motivating philosophies:
 
-* Privacy-first.  This is for sharing with friends and family, not commercial endevors.  If you want a blog for your company, you probably want to use Wordpress instead
+* Privacy-first.  This is for sharing with friends and family, not commercial endevors.  If you want a blog for your company, you probably want to use WordPress instead
 * Easy to use.
 * Low-bandwidth friendly.  Images get downscaled to reduce page load times.  No javascript frameworks.  No ads or trackers.
 * Customizable.  If you want to add custom CSS, you can do that


### PR DESCRIPTION
As per the official logos: https://wordpress.org/about/logos/