### PR TITLE
Add experimental docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+tmp
+node_modules
+*.log
+/log
+/vendor
+.git
+.github

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM ruby:2.7.2-slim-buster
+
+RUN echo "deb http://ftp.us.debian.org/debian testing main contrib non-free" >> /etc/apt/sources.list && \
+    apt-get update -yqq && \
+    apt-get install --no-install-recommends -yqq \
+      autoconf build-essential libpq-dev \
+      nodejs apt-transport-https ca-certificates npm && \
+    npm install --global yarn && \
+    gem install bundler && \
+    useradd --system --uid 541311 --create-home app
+
+
+COPY Gemfile Gemfile.lock Rakefile config.ru .ruby-version ./
+
+# Setting MALLOC_ARENA_MAX to 2 can greatly reduce memory usage
+ENV MALLOC_ARENA_MAX='2'
+
+RUN bundle update --bundler && \
+    bundle config build.bcrypt --use-system-libraries && \
+    bundle install --deployment --without development test
+
+COPY . .
+RUN bin/rails assets:precompile
+
+EXPOSE 3000
+
+CMD ["bin/bootstrap_webserver"]

--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,7 @@ gem 'jbuilder', '~> 2.5'
 
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.1.0', require: false
+gem 'listen', '>= 3.0.5', '< 3.2'
 
 #gem 'aws-sdk-rails', '~> 2.1.0'  #email with AWS SES
 
@@ -67,7 +68,6 @@ end
 group :development do
   # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
   gem 'web-console', '>= 3.3.0'
-  gem 'listen', '>= 3.0.5', '< 3.2'
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'

--- a/README.md
+++ b/README.md
@@ -48,12 +48,10 @@ Note, this requires a little bit more technical knowledge.  You should know how 
 * Note, there are no backups setup.  You may want to backup the database (PostgreSQL) and uploaded images (`/home/pi/simpleblog/storage`).
 
 ## Paid Hosting
-
 Fully managed hosting of your personal Haven is available too, check out: https://havenweb.org/order.html
 
 ## Docker
-Docker deployment is a work-in-progress and untested.  Feel free to checkout the `local` branch which has a Dockerfile you can experiment with.
-
+There is experimental Docker support. It currently does not work with a production environment, will not save files after a restart and is generally not ready for production. Feel free to open up a PR and improve on it. 
 ## Other Linux Systems
 
 Given the differences between Linux platforms I can't give fool-proof deployment instructions for every platform but take a look at the two bash scripts in `deploymentscripts/lib/bash/`.  They are the steps used for installing dependencies and the Haven application in the automated AWS deployment.  There may be differences depending on your distribution.

--- a/bin/bootstrap_webserver
+++ b/bin/bootstrap_webserver
@@ -3,4 +3,4 @@ set -e
 
 bin/rails db:create db:migrate
 
-bin/rails s -e production -p 3000
+bin/rails s -p 3000

--- a/bin/bootstrap_webserver
+++ b/bin/bootstrap_webserver
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+bin/rails db:create db:migrate
+
+bin/rails s -e production -p 3000

--- a/config/database.yml
+++ b/config/database.yml
@@ -3,20 +3,27 @@ default: &default
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   timeout: 5000
   encoding: unicode
+  host: <%= ENV['HAVEN_DB_HOST'] %>
+  database: <%= ENV['HAVEN_DB_NAME'] %>
+  username: <%= ENV['HAVEN_DB_ROLE'] %>
+  password: <%= ENV['HAVEN_DB_PASSWORD'] %>
 
 development:
   <<: *default
-  database: rails_development_db
+  database: haven_development_db
+
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: rails_test_db
+  database: haven_test_db
 
 production:
   <<: *default
+  host: <%= ENV['HAVEN_DB_HOST'] %>
   database: <%= ENV['HAVEN_DB_NAME'] %>
   username: <%= ENV['HAVEN_DB_ROLE'] %>
   password: <%= ENV['HAVEN_DB_PASSWORD'] %>
+

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -12,7 +12,7 @@ amazon:
 #  access_key_id: <%= ENV['AWS_KEY'] %>
 #  secret_access_key: <%= ENV['AWS_SECRET'] %>
   region: us-west-2
-  bucket: <%= ENV['AWS_BUCKET'] %> 
+  bucket: <%= ENV['AWS_BUCKET'] %>
 
 # Remember not to checkin your GCS keyfile to a repository
 # google:

--- a/deploymentscripts/deploy-pi.sh
+++ b/deploymentscripts/deploy-pi.sh
@@ -60,6 +60,7 @@ git checkout local
 bundle config build.bcrypt --use-system-libraries
 bundle install --deployment --without development test
 
+echo 'HAVEN_DB_HOST="postgresql"' >> .env
 echo 'HAVEN_DB_NAME="pi"' >> .env
 echo 'HAVEN_DB_ROLE="pi"' >> .env
 echo "HAVEN_DB_PASSWORD=\"$DB_PASS\"" >> .env
@@ -68,7 +69,7 @@ bin/rails db:create
 bin/rails db:migrate
 bin/rails assets:precompile
 
-# systemd to run the app: /etc/systemd/system/simpleblog.service 
+# systemd to run the app: /etc/systemd/system/simpleblog.service
 echo "[Unit]" > haven.service
 echo "Description=Haven Web App" >> haven.service
 echo "" >> haven.service

--- a/deploymentscripts/lib/bash/ubuntu-deploy.sh
+++ b/deploymentscripts/lib/bash/ubuntu-deploy.sh
@@ -24,6 +24,7 @@ git checkout $BLOG_VERSION ## master if not specified
 ruby deploymentscripts/lib/ruby/set_version.rb $BUCKET_NAME
 
 echo "AWS_BUCKET=\"$BUCKET_NAME\"" >> .env
+echo 'HAVEN_DB_HOST="postgresql"' >> .env
 echo 'HAVEN_DB_NAME="ubuntu"' >> .env
 echo 'HAVEN_DB_ROLE="ubuntu"' >> .env
 echo "HAVEN_DB_PASSWORD=\"$DB_PASS\"" >> .env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,40 @@
+version: '3.7'
+services:
+  haven:
+    build:
+      dockerfile: Dockerfile
+    depends_on:
+      - postgresql
+    ports:
+      - "3000:3000"
+    environment:
+      - RAILS_ENV=development
+      - HAVEN_DB_HOST=postgresql
+      - HAVEN_DB_NAME=haven
+      - HAVEN_DB_ROLE=haven
+      - HAVEN_DB_PASSWORD=supersecretrandomstring
+
+  postgresql:
+    image: postgres:13.2-alpine
+    ports:
+      - "5432:5432"
+    # https://www.postgresql.org/docs/current/static/non-durability.html
+    command: [
+      "postgres",
+      "-c", "max_connections=1000",
+      "-c", "synchronous_commit=off",
+      "-c", "fsync=off",
+      "-c", "full_page_writes=off",
+      "-c", "max_wal_size=4GB",
+      "-c", "checkpoint_timeout=30min",
+      "-c", "wal_level=logical"
+    ]
+    environment:
+      POSTGRES_HOST_AUTH_METHOD: trust
+      POSTGRES_USER: haven
+    volumes:
+      - postgresqldata:/var/lib/postgresql/data
+
+volumes:
+  postgresqldata:
+    external: false


### PR DESCRIPTION
Ref #24. This is a first step in supporting Docker. It is not really ready for prime-time release, but it will build and start correctly when run with `docker-compose up`. It can be useful for development purposes at the moment.

There is a strong dependency on AWS S3 at the moment and that's why I've chosen to set the RAILS_ENV to `development` for the moment. If we really want to make this more portable, we need to lower our dependency on S3; it can be an option, but right now it crashes on startup when there are no S3 credentials. 

Furthermore,  because the GLIBC version included in the base container (`ruby:2.7.2-slim-buster`) is older then version 2.29, Nokogiri would not load correctly. That is temporarely fixed with  `echo "deb http://ftp.us.debian.org/debian testing main contrib non-free" >> /etc/apt/sources.list`, which will download a newer version of the library when installing through `apt-get install build-essential`. 