### PR TITLE
fix(docker-compose): add context keyword

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: '3.7'
 services:
   haven:
     build:
+      context: .
       dockerfile: Dockerfile
     depends_on:
       - postgresql


### PR DESCRIPTION
A simple change, but the docker-compose file does not come up without this on Ubuntu 20.04. 