### PR TITLE
fix upload image button disable text

### DIFF
--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -4,7 +4,7 @@
   <%= form.time_field :time, :style => 'display:inline;', :value => @post.datetime.strftime("%H:%M"), type: (@settings.show_post_date ? :time : :hidden) %>
   <%= form.text_area :content, :rows => 10, :dir => "auto", :style => 'display:block;width:100%;', :oninput => "doRender();", :value => @post.content %>
   <%= form.file_field :pic, :accept => "image/*,.mp4,.mp3", :style => "display:inline;" %>
-  <%= form.submit :value => "Upload Selected Image", :style => "display:inline;" %>
+  <%= form.submit :value => "Upload Selected Image", data: {disable_with: "Upload Selected Image"}, :style => "display:inline;" %>
   <%= form.submit :value => "Save Post", :style => "display:block;" %>
 <% end %>
 


### PR DESCRIPTION
To prevent double-submitting a form, Rails uses JS to disable a form submit button when it is clicked.

Rails was defaulting all buttons on the form to display the same text when disabled, so when creating a post or uploading an image, both submit buttons would be disabled with the text "create form".  This change explicitly specifies which text to use when disabling the upload image button so it doesn't flash with the wrong text.

Fixes #100 