### PR TITLE
force update to latests default gem for base64

### DIFF
--- a/deploymentscripts/lib/bash/ubuntu-prep.sh
+++ b/deploymentscripts/lib/bash/ubuntu-prep.sh
@@ -18,6 +18,7 @@ RUBY_CONFIGURE_OPTS=--disable-install-doc rbenv install 3.1.4
 rbenv global 3.1.4
 gem update --system
 gem update strscan --default #resolves a gem conflict
+gem update base64 --default #resolves a gem conflict
 gem install bundler -v 2.4.12 --no-document
 
 #### Nginx And Passenger #### https://www.phusionpassenger.com/library/install/nginx/install/oss/bionic/


### PR DESCRIPTION
resolves the following error:
```
Could not spawn process for application /var/www/haven: The application encountered the following error: You have already activated base64 0.1.1, but your Gemfile requires base64 0.2.0. Since base64 is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports base64 as a default gem. (Gem::LoadError)
```