### PR TITLE
feat: Implement responsive hamburger menu for mobile

### DIFF
--- a/app/assets/stylesheets/_navigation.scss
+++ b/app/assets/stylesheets/_navigation.scss
@@ -26,6 +26,28 @@
   .hamburger-label {
     display: inline-block; // Show the hamburger icon
     float: right; // Position it to the right
+    cursor: pointer;
+    font-size: 1.8rem; // Made slightly larger for better tap target and visual weight
+    padding-right: 0; // Remove padding from label itself if icon is ::before
+    position: relative; // For potential fine-tuning of ::before positioning
+    width: 1.8rem; // Give it a fixed width
+    height: 1.8rem; // Give it a fixed height
+    text-align: center;
+    color: var(--nc-tx-1); 
+
+    &::before {
+      content: '\2630'; // Unicode for ☰
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+    }
+  }
+
+  // When the hamburger checkbox is checked, change the label to an "X"
+  #hamburger-toggle:checked ~ nav header .hamburger-label::before {
+    content: '\00d7'; // Unicode for ×
+    // font-size: 2rem; // Adjust if 'X' needs different sizing
   }
 
   .nav-links {
@@ -49,5 +71,8 @@
   #hamburger-toggle:checked ~ nav header .nav-links {
     display: block;
     margin-top: 1rem; // Add some space above the expanded links
+    padding-top: 0.5rem; // Add some padding inside the top border
+    border-top: 1px solid var(--nc-bg-3); // Use theme variable for border color
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05); // Subtle shadow downwards
   }
 }

--- a/app/assets/stylesheets/_navigation.scss
+++ b/app/assets/stylesheets/_navigation.scss
@@ -1,0 +1,53 @@
+// Default (Desktop) Styles
+.hamburger-label {
+  display: none; // Hidden on desktop
+  cursor: pointer;
+  font-size: 1.5rem; // Match other header link sizes
+  padding-right: 1rem; // Spacing similar to other links
+  color: var(--nc-tx-1); // Use existing theme variable for text color
+}
+
+.nav-links {
+  display: inline; // Keep links inline on desktop by default
+}
+
+// Mobile Styles
+@media screen and (max-width: 768px) {
+  header {
+    // Adjust header padding on mobile if necessary, or ensure links can wrap
+    // For now, let's assume existing header padding is okay,
+    // but we might need to revisit this if the "Home" link and hamburger cause overflow.
+  }
+
+  .navigation-home {
+    // Potentially adjust padding or size if needed on mobile
+  }
+
+  .hamburger-label {
+    display: inline-block; // Show the hamburger icon
+    float: right; // Position it to the right
+  }
+
+  .nav-links {
+    display: none; // Hide the navigation links by default on mobile
+    width: 100%;  // Make the links container take full width
+    clear: both; // Ensure it clears any floats (like the hamburger icon if it was floated left)
+    
+    a {
+      display: block; // Stack links vertically
+      padding: 0.75rem 0; // Add some padding to each link
+      text-align: left; // Align text to the left
+      border-bottom: 1px solid var(--nc-bg-3); // Separator line, use theme variable
+
+      &:last-child {
+        border-bottom: none; // No border for the last link
+      }
+    }
+  }
+
+  // When the hamburger checkbox is checked, display the nav-links
+  #hamburger-toggle:checked ~ nav header .nav-links {
+    display: block;
+    margin-top: 1rem; // Add some space above the expanded links
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -14,3 +14,4 @@
 @import "misc";
 @import "alert";
 @import "new";
+@import "navigation";

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -35,9 +35,12 @@
 
   </head>
   <body>
+    <input type="checkbox" id="hamburger-toggle" style="display: none;">
     <nav>
     <header>
       <%=link_to "Home", root_path, class: 'navigation-home' %>
+      <label for="hamburger-toggle" class="hamburger-label">&#9776;</label>
+      <div class="nav-links">
         <% if user_signed_in? %>
           <% if current_user.admin == 1 %>
             <%= link_to "Read", read_path %>
@@ -47,6 +50,7 @@
           <%= link_to "Account", edit_user_registration_path %>
           <%= link_to "Logout", destroy_user_session_path, method: :delete  %>
         <% end %>
+      </div>
     </header>
     </nav>
     <div class="container">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -39,7 +39,7 @@
     <nav>
     <header>
       <%=link_to "Home", root_path, class: 'navigation-home' %>
-      <label for="hamburger-toggle" class="hamburger-label">&#9776;</label>
+      <label for="hamburger-toggle" class="hamburger-label"></label>
       <div class="nav-links">
         <% if user_signed_in? %>
           <% if current_user.admin == 1 %>


### PR DESCRIPTION
This commit introduces a responsive navigation bar that collapses into a hamburger menu on mobile devices.

Key changes:
- Modified `app/views/layouts/application.html.erb` to include:
    - A hidden checkbox input for state management.
    - A label styled as a hamburger icon (☰).
    - A wrapper div (`.nav-links`) for the navigation links to be toggled.
- Created `app/assets/stylesheets/_navigation.scss` with styles for:
    - Hiding the hamburger icon and showing links inline on desktop.
    - Showing the hamburger icon and hiding links by default on mobile (max-width: 768px).
    - Toggling the visibility of links when the hamburger icon is clicked, using the :checked pseudo-class on the checkbox.
    - Styling the expanded mobile menu with vertically stacked links.
- Imported the new `_navigation.scss` into `app/assets/stylesheets/application.scss`.

This solution uses only HTML and CSS, as per your requirement, avoiding JavaScript for the toggle functionality.