### PR TITLE
Fix Security Vulnerabilities in Cookies and Views

### DIFF
--- a/app/views/feeds/read.html.erb
+++ b/app/views/feeds/read.html.erb
@@ -31,7 +31,9 @@ end
 <% end %>
 
 <% unless @feed.nil? %>
-  <p><strong>Feed Name: </strong><%= link_to sanitize(@feed.name, tags:[], attributes:[]), @feed.feed_entries.first.link %></p>
+  <% feed_link = @feed.feed_entries.first.link.to_s %>
+  <% feed_link = "#" unless feed_link.start_with?('http://', 'https://') %>
+  <p><strong>Feed Name: </strong><%= link_to sanitize(@feed.name, tags:[], attributes:[]), feed_link %></p>
   <p><strong>Feed URL: </strong><%= @feed.url %>
   <br/>
   <p><%= link_to 'Delete this feed', feed_path(@feed),
@@ -44,11 +46,13 @@ end
 <% entry_number = 0 %>
 <% @entries.each do |entry| %>
   <div id="entry_<%= entry_number %>">
-    <h1><%= link_to sanitize(entry.title, tags:[], attributes:[]), entry.link, rel: "nofollow", target: "_blank" %></h1>
+    <% entry_link = entry.link.to_s %>
+    <% entry_link = "#" unless entry_link.start_with?('http://', 'https://') %>
+    <h1><%= link_to sanitize(entry.title, tags:[], attributes:[]), entry_link, rel: "nofollow", target: "_blank" %></h1>
     <a href="#entry_<%= entry_number+1 %>" class="feed_entry_skip">[next]</a>
   </div>
   <p><strong><%= link_to sanitize(entry.feed.name, tags:[], attributes:[]), read_feed_path(entry.feed) %></strong> <%= entry.published.strftime("%B %e, %Y") %></p>
-  <%= rel_to_abs(sanitize(sanitize(entry.content, scrubber: no_style_or_scripts), tags: safe_tags, attributes: safe_attr), entry.feed.url).html_safe %>
+  <%= sanitize(rel_to_abs(sanitize(entry.content, scrubber: no_style_or_scripts), entry.feed.url), tags: safe_tags, attributes: safe_attr) %>
   <% unless entry.audio.nil? %>
     <audio controls>
       <source src="<%= entry.audio %>" type="audio/mpeg">

--- a/config/initializers/cookies_serializer.rb
+++ b/config/initializers/cookies_serializer.rb
@@ -13,4 +13,4 @@
 #
 # It is fine to use `:hybrid` long term; you should do that until you're confident *all* your cookies
 # have been converted to JSON.
-Rails.application.config.action_dispatch.cookies_serializer = :hybrid
+Rails.application.config.action_dispatch.cookies_serializer = :json


### PR DESCRIPTION
This PR fixes the security vulnerabilities identified by Brakeman.

The following warnings were addressed:
1.  **Medium Confidence: Remote Code Execution via Cookie Serialization.** Changed the `cookies_serializer` in `config/initializers/cookies_serializer.rb` from `:hybrid` to `:json`.
2.  **Weak Confidence: Cross-Site Scripting via `link_to` href.** Added logic to filter and validate `feed_link` and `entry_link` URLs to ensure they explicitly begin with `http://` or `https://` before passing them to the `link_to` helper in `app/views/feeds/read.html.erb`.
3.  **Weak Confidence: Cross-Site Scripting via `html_safe`.** Removed the direct call to `.html_safe` on the output of `rel_to_abs` and instead passed the output through the `sanitize` helper in `app/views/feeds/read.html.erb`.

All relevant Brakeman warnings have been resolved. The remaining high-confidence warning regarding the EOL Rails dependency was not addressed, as it falls outside the scope of fixing these specific code vulnerabilities.

---
*PR created automatically by Jules for task [5733965881957141522](https://jules.google.com/task/5733965881957141522) started by @mawise*